### PR TITLE
Database adapter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,7 @@
 require 'sinatra/base'
 require './lib/user'
 require './lib/space'
+require_relative './database_connection_setup'
 
 class Makersbnb < Sinatra::Base
   get '/' do

--- a/database_connection_setup.rb
+++ b/database_connection_setup.rb
@@ -1,0 +1,7 @@
+require_relative './lib/database_connection'
+
+if ENV['RACK_ENV'] == 'test'
+  DatabaseConnection.setup('makersbnb_test')
+else
+  DatabaseConnection.setup('makersbnb')
+end

--- a/lib/database_connection.rb
+++ b/lib/database_connection.rb
@@ -1,0 +1,16 @@
+require 'pg'
+
+class DatabaseConnection
+  def self.setup(db_name)
+    @connection = PG.connect(dbname: db_name)
+  end
+
+  def self.connection
+    @connection
+  end
+
+  def self.query(string)
+    @connection.exec(string)
+  end
+
+end

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -1,7 +1,6 @@
 class Space
   def self.list_spaces
-    connection = PG.connect :dbname => 'makersbnb_test'
-    all_space_records = connection.exec "SELECT * FROM spaces;"
+    all_space_records = DatabaseConnection.query "SELECT * FROM spaces;"
     all_space_records.map do |record|
       record['spacename']
     end

--- a/spec/database_connection_spec.rb
+++ b/spec/database_connection_spec.rb
@@ -1,0 +1,28 @@
+require 'database_connection'
+
+describe DatabaseConnection do
+  describe '.setup' do
+    it 'sets up a connection' do
+      expect(PG).to receive(:connect).with(dbname: 'makersbnb_test')
+
+      DatabaseConnection.setup('makersbnb_test')
+    end
+  end
+  describe '.connection' do
+    it 'this connection is persistent' do
+    # Grab the connection as a return value from the .setup method
+      connection = DatabaseConnection.setup('makersbnb_test')
+
+      expect(DatabaseConnection.connection).to eq connection
+    end
+  end
+  describe '.query' do
+    it 'executes a query via PG' do
+      connection = DatabaseConnection.setup('makersbnb_test')
+
+      expect(connection).to receive(:exec).with("SELECT * FROM spaces;")
+
+      DatabaseConnection.query("SELECT * FROM spaces;")
+    end
+  end
+end


### PR DESCRIPTION
This adds a database adapter class to the project - usage as follows:

You no longer need to specify which database you want to connect to and query, instead, for any SQL queries, you only need to use

>sqlstring = "SELECT * FROM spaces;"
>DatabaseConnection.query(sqlstring)

This will return an object as if you'd run connection.exec. You can use this in any classes, and it will route to either the live or test database depending on whether you're running rspec. 