### PR TITLE
Integrate comment logic with front end

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -34,13 +34,18 @@ class Makersbnb < Sinatra::Base
   end
 
   get '/space_profile/:id' do
-    @comments = Comment.show_comments_by_space(params[:id])
+    @comments = Comment.show_comments_by_space(spaceid: params['id'])
+    @space = Space.view_space_details(spaceid: params['id'])
     erb :space_profile
   end
 
-  post '/create_comment' do
-
-    redirect '/space_profile/:id'
+  post '/create_comment/:id' do
+    Comment.create(
+      userid: session['user'].userid,
+      spaceid: params['id'],
+      comment_text: params['comment_text']
+    )
+    redirect "/space_profile/#{params['id']}"
   end
 
   get '/create-a-space' do

--- a/db/migrations/01_create_users_table.sql
+++ b/db/migrations/01_create_users_table.sql
@@ -1,3 +1,3 @@
 CREATE TABLE users(id SERIAL PRIMARY KEY, username VARCHAR(60) UNIQUE, password VARCHAR(15), email VARCHAR(60) UNIQUE);
 CREATE TABLE spaces (id SERIAL PRIMARY KEY, owner INT REFERENCES users(id), spacename VARCHAR, description VARCHAR, price DECIMAL(6,2));
-CREATE TABLE comments (id SERIAL PRIMARY KEY, space INTEGER REFERENCES spaces(id), commenter INTEGER REFERENCES users(id), comment_text VARCHAR(50));
+CREATE TABLE comments (id SERIAL PRIMARY KEY, space INTEGER REFERENCES spaces(id), commenter INTEGER REFERENCES users(id), commenttext VARCHAR(50));

--- a/lib/comments.rb
+++ b/lib/comments.rb
@@ -8,29 +8,29 @@ class Comment
     @comment_text = comment_text
   end
 
-  def self.create(userid, spaceid, comment_text)
+  def self.create(userid:, spaceid:, comment_text:)
     result = DatabaseConnection.query(
-      "INSERT INTO comments (commenter, space, comment_text)
+      "INSERT INTO comments (commenter, space, commenttext)
       VALUES (#{userid}, #{spaceid}, '#{comment_text}')
-      RETURNING id, commenter, space, comment_text;"
+      RETURNING id, commenter, space, commenttext;"
     )
     Comment.new(
       id: result[0]['id'],
-      userid: result[0]['userid'],
-      spaceid: result[0]['spaceid'],
-      comment_text: result[0]['comment_text']
+      userid: result[0]['commenter'],
+      spaceid: result[0]['space'],
+      comment_text: result[0]['commenttext']
     )
   end
 
-  def self.show_comments_by_space(spaceid)
+  def self.show_comments_by_space(spaceid:)
     result = DatabaseConnection.query(
-      "SELECT comments.comment_text, users.username FROM comments
+      "SELECT comments.commenttext, users.username FROM comments
       INNER JOIN users
       ON comments.commenter = users.id
       WHERE comments.space = #{spaceid};"
     )
     result.map do |comment|
-      { comment_text: comment['comment_text'], username: comment['username'] }
+      { comment_text: comment['commenttext'], username: comment['username'] }
     end
   end
 

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -26,4 +26,10 @@ class Space
       spacename: result[0]['spacename']
     )
   end
+
+  def self.view_space_details(spaceid:)
+    result = DatabaseConnection.query "SELECT * FROM spaces
+      WHERE id='#{spaceid}';"
+    { id: result[0]['id'], spacename: result[0]['spacename'] }
+  end
 end

--- a/spec/comments_spec.rb
+++ b/spec/comments_spec.rb
@@ -1,15 +1,22 @@
 describe 'User can request a booking after viewing a space' do
   describe '.create' do
     it 'allows a user to enter comments' do
-      comment = Comment.create(1, 1, "Beautiful garden")
+      comment = Comment.create(
+        userid: 1,
+        spaceid: 1,
+        comment_text: "Beautiful garden")
       expect(comment.comment_text).to eq("Beautiful garden")
     end
   end
 
   describe '.show_comments' do
     it 'shows a list of comments for a space' do
-      comment = Comment.create(1, 1, "Bad garden")
-      comment_list = Comment.show_comments_by_space(1)
+      comment = Comment.create(
+        userid: 1,
+        spaceid: 1,
+        comment_text: "Bad garden"
+      )
+      comment_list = Comment.show_comments_by_space(spaceid: 1)
       expect(comment.comment_text).to eq(comment_list[0][:comment_text])
     end
   end

--- a/spec/feature/viewing_spaces_page_spec.rb
+++ b/spec/feature/viewing_spaces_page_spec.rb
@@ -1,15 +1,26 @@
 feature 'viewing the list of a single spaces' do
   scenario 'user can see all the details of a single space on Makersbnb' do
+    visit '/'
+    fill_in('login_username', with: DEFAULT_USER[:username])
+    fill_in('login_password', with: DEFAULT_USER[:password])
+    click_button('Log in')
     visit '/spaces'
-    click_button('View Profile')
-    expect(page).to have_content 'Booking comment'
+    click_link(DEFAULT_SPACE[:spacename])
+    expect(page).to have_content DEFAULT_SPACE[:spacename]
   end
 
-  scenario 'user can enter a booking message and see it on booking page' do
+  scenario 'user can enter a comment and see it on the space page' do
+    visit '/'
+    fill_in('login_username', with: DEFAULT_USER[:username])
+    fill_in('login_password', with: DEFAULT_USER[:password])
+    click_button('Log in')
     visit '/spaces'
-    click_button('View Profile')
-    fill_in('Comments', with: 'Request booking')
-    expect(page).to have_content 'Request booking'
+    click_link(DEFAULT_SPACE[:spacename])
+    comment = 'I want to book this property'
+    fill_in('comment_text', with: comment)
+    click_button('Submit')
+    visit '/spaces'
+    click_link(DEFAULT_SPACE[:spacename])
+    expect(page).to have_content 'I want to book this property'
   end
-
 end

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -1,5 +1,4 @@
 describe 'Space' do
-
   context '#list_spaces' do
     it 'returns a list of the spaces object with id numbers' do
       list_of_spaces = Space.list_spaces
@@ -23,6 +22,17 @@ describe 'Space' do
         space.spacename == 'My House'
       }
       expect(my_house).not_to be nil
+    end
+  end
+
+  context '#view_space_details' do
+    it 'returns the details for a given space id' do
+      my_house = Space.create_space(
+        spacename: 'My House',
+        ownerid: DEFAULT_USER[:id]
+      )
+      house_details = Space.view_space_details(spaceid: my_house.id)
+      expect(house_details[:spacename]).to eq 'My House'
     end
   end
 end

--- a/views/space_profile.erb
+++ b/views/space_profile.erb
@@ -5,25 +5,23 @@
     <title>Space profile</title>
   </head>
   <body>
-    <div class="">
+    <div class="spacename">
       <h1>
-         <%# <%= @space.name %>
-        Hello Space
+        <%= @space[:spacename] %>
       </h1>
     </div>
+<% if false %>
     <div class="">
       <p>
-        Lorem Ipsum
-        <%# <%= @space.description %>
+        <%= @space[:description] %>
       </p>
     </div>
     <div class="">
       <p>
-        £200
-        <%# <%= @space.price %>
+        <%= @space[:price] %>
       </p>
     </div>
-
+<% end %>
     <div class="comments-list">
       Previous comments
       <ul>
@@ -36,10 +34,10 @@
         </ul>
     </div>
 
-    <form class="" action="/create_comment" method="post">
+    <form class="" action="/create_comment/<%= params['id'] %>" method="post">
       <label for="">
         Make comment:
-        <input type="text" name="content" value="">
+        <input type="text" name="comment_text" placeholder="Comment here">
         <input type="submit" name="" value="Submit">
       </label>
     </form>


### PR DESCRIPTION
A change was made to the comments table in the databases, removing the
underscore in comment_text as _ may act as a wildcard in some queries.
The SQL file in db/migrations was updated to reflect this.