### PR TITLE
Availability of spaces

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -68,9 +68,13 @@ class Makersbnb < Sinatra::Base
       spacename: params[:space_name]
     )
     if params[:start_availability] != "" && params[:end_availability] != ""
-      (params[:start_availability]..params[:end_availability]).each do |date|
-        Space.add_availability(spaceid: new_space.id, date: date)
-      end
+      start_date = Date.strptime(params[:start_availability], '%Y-%m-%d')
+      end_date = Date.strptime(params[:end_availability], '%Y-%m-%d')
+      Space.add_availability_range(
+        spaceid: new_space.id,
+        start_date: start_date,
+        end_date: end_date
+      )
     end
     redirect '/spaces'
   end

--- a/app.rb
+++ b/app.rb
@@ -42,6 +42,7 @@ class Makersbnb < Sinatra::Base
   get '/space_profile/:id' do
     @comments = Comment.show_comments_by_space(spaceid: params['id'])
     @space = Space.view_space_details(spaceid: params['id'])
+    @dates = Space.view_availability(spaceid: params['id'])
     erb :space_profile
   end
 

--- a/app.rb
+++ b/app.rb
@@ -63,10 +63,18 @@ class Makersbnb < Sinatra::Base
   post '/add-space' do
     user = session['user']
     id = User.get_user_id(username: user.username)
-    Space.create_space(
+    new_space = Space.create_space(
       ownerid: id,
       spacename: params[:space_name]
     )
+    if params[:start_availability] != "" && params[:end_availability] != ""
+      puts 'adding availabilities'
+      (Date.strptime(params[:start_availability], '%d/%m/%Y')..Date.strptime(params[:end_availability], '%d/%m/%Y')).each do |date|
+        date = date.to_s.split '-'
+        date = date.reverse.join '/'
+        Space.add_availability(spaceid: new_space.id, date: date)
+      end
+    end
     redirect '/spaces'
   end
 

--- a/app.rb
+++ b/app.rb
@@ -68,9 +68,7 @@ class Makersbnb < Sinatra::Base
       spacename: params[:space_name]
     )
     if params[:start_availability] != "" && params[:end_availability] != ""
-      (Date.strptime(params[:start_availability], '%d/%m/%Y')..Date.strptime(params[:end_availability], '%d/%m/%Y')).each do |date|
-        date = date.to_s.split '-'
-        date = date.reverse.join '/'
+      (params[:start_availability]..params[:end_availability]).each do |date|
         Space.add_availability(spaceid: new_space.id, date: date)
       end
     end

--- a/app.rb
+++ b/app.rb
@@ -68,7 +68,6 @@ class Makersbnb < Sinatra::Base
       spacename: params[:space_name]
     )
     if params[:start_availability] != "" && params[:end_availability] != ""
-      puts 'adding availabilities'
       (Date.strptime(params[:start_availability], '%d/%m/%Y')..Date.strptime(params[:end_availability], '%d/%m/%Y')).each do |date|
         date = date.to_s.split '-'
         date = date.reverse.join '/'

--- a/db/migrations/01_create_users_table.sql
+++ b/db/migrations/01_create_users_table.sql
@@ -1,3 +1,4 @@
 CREATE TABLE users(id SERIAL PRIMARY KEY, username VARCHAR(60) UNIQUE, password VARCHAR(15), email VARCHAR(60) UNIQUE);
 CREATE TABLE spaces (id SERIAL PRIMARY KEY, owner INT REFERENCES users(id), spacename VARCHAR, description VARCHAR, price DECIMAL(6,2));
 CREATE TABLE comments (id SERIAL PRIMARY KEY, space INTEGER REFERENCES spaces(id), commenter INTEGER REFERENCES users(id), commenttext VARCHAR(50));
+CREATE TABLE availability(id SERIAL PRIMARY KEY, space INTEGER REFERENCES spaces(id), availabledate DATE, unavailable BOOLEAN DEFAULT FALSE);

--- a/docs/database-model.md
+++ b/docs/database-model.md
@@ -25,7 +25,7 @@
 #### Table name: availability
 - id (PK)
 - space (FK -> spaces::id)
-- date
+- availabledate
 - unavailable
 
 #### Table name: comments

--- a/docs/domain_model_methods.md
+++ b/docs/domain_model_methods.md
@@ -21,6 +21,7 @@
 * update_space_details
 * view_availability
 * add_availability
+* add_availability_range
 * make_unavailable
 
 ****Bookings****

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -32,4 +32,12 @@ class Space
       WHERE id='#{spaceid}';"
     { id: result[0]['id'], spacename: result[0]['spacename'] }
   end
+
+  def self.view_availability(spaceid:)
+    result = DatabaseConnection.query "SELECT * FROM availability
+      WHERE space=#{spaceid};"
+    result.map do |availability|
+      availability['availabledate']
+    end
+  end
 end

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -48,4 +48,10 @@ class Space
       INTO availability (space, availabledate)
       VALUES ('#{spaceid}', '#{date}');"
   end
+
+  def self.add_availability_range(spaceid:, start_date:, end_date:)
+    (start_date..end_date).each do |date|
+      Space.add_availability(spaceid: spaceid, date: date)
+    end
+  end
 end

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -44,7 +44,6 @@ class Space
   end
 
   def self.add_availability(spaceid:, date:)
-    puts 'in the model'
     date = date.split '/'
     date = date.reverse.join '-'
     DatabaseConnection.query "INSERT

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -44,8 +44,6 @@ class Space
   end
 
   def self.add_availability(spaceid:, date:)
-    date = date.split '/'
-    date = date.reverse.join '-'
     DatabaseConnection.query "INSERT
       INTO availability (space, availabledate)
       VALUES ('#{spaceid}', '#{date}');"

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -34,10 +34,20 @@ class Space
   end
 
   def self.view_availability(spaceid:)
-    result = DatabaseConnection.query "SELECT * FROM availability
+    result = DatabaseConnection.query "SELECT
+      to_char(availabledate, 'dd/mm/yyyy')
+      FROM availability
       WHERE space=#{spaceid};"
     result.map do |availability|
-      availability['availabledate']
+      availability['to_char']
     end
+  end
+
+  def self.add_availability(spaceid:, date:)
+    date = date.split '/'
+    date = date.reverse.join '-'
+    DatabaseConnection.query "INSERT
+      INTO availability (space, availabledate)
+      VALUES ('#{spaceid}', '#{date}');"
   end
 end

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -44,6 +44,7 @@ class Space
   end
 
   def self.add_availability(spaceid:, date:)
+    puts 'in the model'
     date = date.split '/'
     date = date.reverse.join '-'
     DatabaseConnection.query "INSERT

--- a/spec/comments_spec.rb
+++ b/spec/comments_spec.rb
@@ -2,8 +2,8 @@ describe 'User can request a booking after viewing a space' do
   describe '.create' do
     it 'allows a user to enter comments' do
       comment = Comment.create(
-        userid: 1,
-        spaceid: 1,
+        userid: DEFAULT_USER[:id],
+        spaceid: DEFAULT_SPACE[:id],
         comment_text: "Beautiful garden")
       expect(comment.comment_text).to eq("Beautiful garden")
     end
@@ -12,11 +12,11 @@ describe 'User can request a booking after viewing a space' do
   describe '.show_comments' do
     it 'shows a list of comments for a space' do
       comment = Comment.create(
-        userid: 1,
-        spaceid: 1,
+        userid: DEFAULT_USER[:id],
+        spaceid: DEFAULT_SPACE[:id],
         comment_text: "Bad garden"
       )
-      comment_list = Comment.show_comments_by_space(spaceid: 1)
+      comment_list = Comment.show_comments_by_space(spaceid: DEFAULT_SPACE[:id])
       expect(comment.comment_text).to eq(comment_list[0][:comment_text])
     end
   end

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -1,14 +1,15 @@
 DEFAULT_USER = {
-  id: 1,
+  id: 0,
   username: 'Adam',
   email: 'antman@pop.com',
   password: 'bacon'
 }
-DEFAULT_SPACE = { id: 1, spacename: 'Pickle Place' }
+DEFAULT_SPACE = { id: 0, spacename: 'Pickle Place' }
 DEFAULT_AVAILABILITY = {
-  id: 1,
+  id: 0,
   spaceid: DEFAULT_SPACE[:id],
-  date: '2019-02-27'
+  date: '2019-02-27',
+  formatted_date: '27/02/2019'
 }
 
 def set_up_database

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -11,6 +11,8 @@ DEFAULT_AVAILABILITY = {
   date: '2019-02-27',
   formatted_date: '27/02/2019'
 }
+DEFAULT_START_AVAILABILITY = Date.new(2019, 04, 12)
+DEFAULT_END_AVAILABILITY = Date.new(2019, 04, 15)
 
 def set_up_database
   clear_database

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -5,6 +5,7 @@ DEFAULT_USER = {
   password: 'bacon'
 }
 DEFAULT_SPACE = { id: 1, spacename: 'Pickle Place' }
+DEFAULT_AVAILABILITY = { id: 1, spaceid: DEFAULT_SPACE[:id], date: '20190227' }
 
 def set_up_database
   clear_database
@@ -19,6 +20,7 @@ end
 def populate_database
   add_default_user
   add_default_space
+  add_default_availability
 end
 
 def add_default_user
@@ -39,5 +41,15 @@ def add_default_space
       #{DEFAULT_SPACE[:id]},
       #{DEFAULT_USER[:id]},
       '#{DEFAULT_SPACE[:spacename]}'
+    );"
+end
+
+def add_default_availability
+  connection = PG.connect :dbname => 'makersbnb_test'
+  connection.exec "INSERT INTO availability (id, space, availabledate)
+    VALUES (
+      #{DEFAULT_AVAILABILITY[:id]},
+      #{DEFAULT_AVAILABILITY[:spaceid]},
+      '#{DEFAULT_AVAILABILITY[:date]}'
     );"
 end

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -13,7 +13,7 @@ end
 
 def clear_database
   connection = PG.connect :dbname => 'makersbnb_test'
-  connection.exec "TRUNCATE TABLE spaces, users, comments"
+  connection.exec "TRUNCATE TABLE spaces, users, comments, availability"
 end
 
 def populate_database

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -5,7 +5,11 @@ DEFAULT_USER = {
   password: 'bacon'
 }
 DEFAULT_SPACE = { id: 1, spacename: 'Pickle Place' }
-DEFAULT_AVAILABILITY = { id: 1, spaceid: DEFAULT_SPACE[:id], date: '20190227' }
+DEFAULT_AVAILABILITY = {
+  id: 1,
+  spaceid: DEFAULT_SPACE[:id],
+  date: '2019-02-27'
+}
 
 def set_up_database
   clear_database

--- a/spec/feature/create_space_spec.rb
+++ b/spec/feature/create_space_spec.rb
@@ -7,4 +7,17 @@ feature 'adding a new space' do
     visit '/spaces'
     expect(page).to have_content 'Dunroamin'
   end
+
+  scenario 'set the available dates when creating a space' do
+    test_login
+    visit '/create-a-space'
+    fill_in('space_name', with: 'Spaceship')
+    fill_in('start_availability', with: '01/01/2019')
+    fill_in('end_availability', with: '10/01/2019')
+    click_button('Publish my space')
+    click_link('Spaceship')
+    expect(page).to have_content '01/01/2019'
+    expect(page).to have_content '05/01/2019'
+    expect(page).to have_content '10/01/2019'
+  end
 end

--- a/spec/feature/create_space_spec.rb
+++ b/spec/feature/create_space_spec.rb
@@ -12,8 +12,8 @@ feature 'adding a new space' do
     test_login
     visit '/create-a-space'
     fill_in('space_name', with: 'Spaceship')
-    fill_in('start_availability', with: Date.new(2019,01,01))
-    fill_in('end_availability', with: Date.new(2019,01,10))
+    fill_in('start_availability', with: Date.new(2019, 01, 01))
+    fill_in('end_availability', with: Date.new(2019, 01, 10))
     click_button('Publish my space')
     click_link('Spaceship')
     expect(page).to have_content '01/01/2019'

--- a/spec/feature/create_space_spec.rb
+++ b/spec/feature/create_space_spec.rb
@@ -12,8 +12,8 @@ feature 'adding a new space' do
     test_login
     visit '/create-a-space'
     fill_in('space_name', with: 'Spaceship')
-    fill_in('start_availability', with: '01/01/2019')
-    fill_in('end_availability', with: '10/01/2019')
+    fill_in('start_availability', with: Date.new(2019,01,01))
+    fill_in('end_availability', with: Date.new(2019,01,10))
     click_button('Publish my space')
     click_link('Spaceship')
     expect(page).to have_content '01/01/2019'

--- a/spec/feature/viewing_spaces_page_spec.rb
+++ b/spec/feature/viewing_spaces_page_spec.rb
@@ -17,4 +17,11 @@ feature 'viewing the list of a single spaces' do
     click_link(DEFAULT_SPACE[:spacename])
     expect(page).to have_content 'I want to book this property'
   end
+
+  scenario 'user can see a list of the available dates of a space' do
+    test_login
+    visit '/spaces'
+    click_link(DEFAULT_SPACE[:spacename])
+    expect(page).to have_content DEFAULT_AVAILABILITY[:formatted_date]
+  end
 end

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -50,4 +50,40 @@ describe 'Space' do
         .to include '17/12/2018'
     end
   end
+
+  context '#add_availability_range' do
+    it 'adds all dates from start to end inclusive' do
+      start_date = DEFAULT_START_AVAILABILITY
+      end_date = DEFAULT_END_AVAILABILITY
+      Space.add_availability_range(
+        spaceid: DEFAULT_SPACE[:id],
+        start_date: start_date,
+        end_date: end_date
+      )
+      (start_date..end_date).each do |date|
+        day = date.day.to_s.rjust(2, "0")
+        month = date.month.to_s.rjust(2, "0")
+        year = date.year
+        expect(Space.view_availability(spaceid: DEFAULT_SPACE[:id]))
+          .to include "#{day}/#{month}/#{year}"
+      end
+    end
+
+    it 'can handle start and end dates in different months/years' do
+      start_date = Date.new(2018, 12, 30)
+      end_date = Date.new(2019, 01, 04)
+      Space.add_availability_range(
+        spaceid: DEFAULT_SPACE[:id],
+        start_date: start_date,
+        end_date: end_date
+      )
+      (start_date..end_date).each do |date|
+        day = date.day.to_s.rjust(2, "0")
+        month = date.month.to_s.rjust(2, "0")
+        year = date.year
+        expect(Space.view_availability(spaceid: DEFAULT_SPACE[:id]))
+          .to include "#{day}/#{month}/#{year}"
+      end
+    end
+  end
 end

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -45,7 +45,7 @@ describe 'Space' do
 
   context '#add_availability' do
     it 'adds an available date to the database ' do
-      Space.add_availability(spaceid: DEFAULT_SPACE[:id], date: '17/12/2018')
+      Space.add_availability(spaceid: DEFAULT_SPACE[:id], date: '2018-12-17')
       expect(Space.view_availability(spaceid: DEFAULT_SPACE[:id]))
         .to include '17/12/2018'
     end

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -35,4 +35,17 @@ describe 'Space' do
       expect(house_details[:spacename]).to eq 'My House'
     end
   end
+
+  context '#view_availability' do
+    it 'returns the list of available dates for a space' do
+      expect(space.view_availability).to include DEFAULT_AVAILABILITY[:date]
+    end
+  end
+
+  context '#add_availability' do
+    it 'adds an available date to the database ' do
+      Space.add_availability(spaceid: DEFAULT_SPACE[:id], date: '17/12/2018')
+      expect(space.view_availability).to include '17/12/2018'
+    end
+  end
 end

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -38,14 +38,16 @@ describe 'Space' do
 
   context '#view_availability' do
     it 'returns the list of available dates for a space' do
-      expect(space.view_availability).to include DEFAULT_AVAILABILITY[:date]
+      expect(Space.view_availability(spaceid: DEFAULT_SPACE[:id]))
+        .to include DEFAULT_AVAILABILITY[:date]
     end
   end
 
   context '#add_availability' do
     it 'adds an available date to the database ' do
       Space.add_availability(spaceid: DEFAULT_SPACE[:id], date: '17/12/2018')
-      expect(space.view_availability).to include '17/12/2018'
+      expect(Space.view_availability(spaceid: DEFAULT_SPACE[:id]))
+        .to include '17/12/2018'
     end
   end
 end

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -5,8 +5,8 @@ describe 'Space' do
 
       expect(list_of_spaces.length).to eq 1
       expect(list_of_spaces[0]).to be_a Space
-      expect(list_of_spaces[0].id).to eq("1")
-      expect(list_of_spaces[0].spacename).to eq("Pickle Place")
+      expect(list_of_spaces[0].id).to eq DEFAULT_SPACE[:id].to_s
+      expect(list_of_spaces[0].spacename).to eq DEFAULT_SPACE[:spacename]
     end
   end
 
@@ -39,7 +39,7 @@ describe 'Space' do
   context '#view_availability' do
     it 'returns the list of available dates for a space' do
       expect(Space.view_availability(spaceid: DEFAULT_SPACE[:id]))
-        .to include DEFAULT_AVAILABILITY[:date]
+        .to include DEFAULT_AVAILABILITY[:formatted_date]
     end
   end
 

--- a/views/create_space.erb
+++ b/views/create_space.erb
@@ -9,8 +9,8 @@
       then click 'Publish my space'</h1>
     <form action='/add-space' method='post'>
       <input type='text' name='space_name' placeholder='My space is called...'>
-      <input type='text' name='start_availability' placeholder='Available from'>
-      <input type='text' name='end_availability' placeholder='Available to'>
+      <input type='date' name='start_availability' placeholder='Available from'>
+      <input type='date' name='end_availability' placeholder='Available to'>
       <input type='submit' value='Publish my space'>
     </form>
     <% if @user %>

--- a/views/create_space.erb
+++ b/views/create_space.erb
@@ -5,13 +5,23 @@
     <title>MakersBnB</title>
   </head>
   <body>
-    <h1>Give your space a name and confirm your username,
-      then click 'Publish my space'</h1>
+    <h1>Give your space a name, then click 'Publish my space'</h1>
     <form action='/add-space' method='post'>
-      <input type='text' name='space_name' placeholder='My space is called...'>
-      <input type='date' name='start_availability' placeholder='Available from'>
-      <input type='date' name='end_availability' placeholder='Available to'>
-      <input type='submit' value='Publish my space'>
+      <p>
+        <input type='text' name='space_name' placeholder='My space is called...'>
+        Your space's name!
+      </p>
+      <p>
+        <input type='date' name='start_availability'>
+        The first date your space is available
+      </p>
+      <p>
+        <input type='date' name='end_availability'>
+        The last date your space is available
+      </p>
+      <p>
+        <input type='submit' value='Publish my space'>
+      </p>
     </form>
     <% if @user %>
       <p>You are logged in as: <%= @user.username %></p>

--- a/views/create_space.erb
+++ b/views/create_space.erb
@@ -9,6 +9,8 @@
       then click 'Publish my space'</h1>
     <form action='/add-space' method='post'>
       <input type='text' name='space_name' placeholder='My space is called...'>
+      <input type='text' name='start_availability' placeholder='Available from'>
+      <input type='text' name='end_availability' placeholder='Available to'>
       <input type='submit' value='Publish my space'>
     </form>
     <% if @user %>

--- a/views/space_profile.erb
+++ b/views/space_profile.erb
@@ -22,6 +22,19 @@
       </p>
     </div>
 <% end %>
+  <br>
+    <div class="available-dates">
+      <p>
+        Available Dates
+        <ul>
+            <% @dates.each do |date| %>
+            <li>
+              <%= date %>
+            </li>
+            <% end %>
+          </ul>
+      </p>
+    </div>
     <div class="comments-list">
       Previous comments
       <ul>


### PR DESCRIPTION
Availability dates are listed individually on the space profile page.
Availability start and end dates can be specified when the space is created. If left blank, the space is created with no availability. The input type for start and end dates is 'text' rather than 'date' as different programs seem to parse the 'date' type in different ways, causing discrepancies between RSpec and Rackup behaviours.