### PR TITLE
Check availability

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -83,6 +83,11 @@ class Makersbnb < Sinatra::Base
   end
 
   post '/create_booking/:id' do
+    raise 'Date range unavailable' unless Space.check_availability_range(
+      spaceid: params['id'],
+      start_date: params['start_date'],
+      end_date: params['end_date']
+    )
     Booking.create_booking(userid: session['user'].userid,
       spaceid: params['id'] ,
       start_date: params['start_date'],

--- a/lib/booking.rb
+++ b/lib/booking.rb
@@ -9,20 +9,20 @@ class Booking
     @confirmed = confirmed
   end
 
-  def self.create_booking(userid:, spaceid:, start_date:, end_date: )
+  def self.create_booking(userid:, spaceid:, start_date:, end_date:)
     result = DatabaseConnection.query("INSERT
       INTO bookings (spaceid, hirerid, startdate, enddate)
       VALUES (#{spaceid}, #{userid}, '#{start_date}', '#{end_date}')
       RETURNING spaceid, hirerid, startdate, enddate, confirmed;
       ")
 
-      Booking.new(
-        start_date: result[0]['startdate'],
-        end_date: result[0]['enddate'],
-        userid: result[0]['hirerid'],
-        spaceid: result[0]['spaceid'],
-        confirmed: result[0]['confirmed']
-      )
+    Booking.new(
+      start_date: result[0]['startdate'],
+      end_date: result[0]['enddate'],
+      userid: result[0]['hirerid'],
+      spaceid: result[0]['spaceid'],
+      confirmed: result[0]['confirmed']
+    )
   end
 
   def self.list_bookings_by_user(userid:)

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -54,4 +54,11 @@ class Space
       Space.add_availability(spaceid: spaceid, date: date)
     end
   end
+
+  def self.check_availability(spaceid:, date:)
+    result = DatabaseConnection.query("SELECT *
+      FROM availability
+      WHERE space = #{spaceid} and availabledate = '#{date}';")
+    result.ntuples > 0
+  end
 end

--- a/lib/space.rb
+++ b/lib/space.rb
@@ -61,4 +61,11 @@ class Space
       WHERE space = #{spaceid} and availabledate = '#{date}';")
     result.ntuples > 0
   end
+
+  def self.check_availability_range(spaceid:, start_date:, end_date:)
+    (start_date..end_date).each do |date|
+      return false unless Space.check_availability(spaceid: spaceid, date: date)
+    end
+    return true
+  end
 end

--- a/spec/feature/create_a_booking_spec.rb
+++ b/spec/feature/create_a_booking_spec.rb
@@ -2,8 +2,8 @@ feature 'User submits a booking request' do
   scenario 'user makes a booking request on a space and can see all requests' do
     test_login
     click_link(DEFAULT_SPACE[:spacename])
-    fill_in('start_date', with: '2018-12-20')
-    fill_in('end_date', with: '2018-12-23')
+    fill_in('start_date', with: DEFAULT_AVAILABILITY[:date])
+    fill_in('end_date', with: DEFAULT_AVAILABILITY[:date])
     click_button('Request booking')
     expect(page).to have_content("Booking request for #{DEFAULT_SPACE[:spacename]} pending")
   end

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -86,4 +86,20 @@ describe 'Space' do
       end
     end
   end
+
+  describe '.check_availability' do
+    it 'checks a day to get back true when the date is available' do
+      expect(Space.check_availability(
+        spaceid: DEFAULT_SPACE[:id],
+        date: DEFAULT_AVAILABILITY[:date])
+      ).to be(true)
+    end
+
+    it 'checks an unavailable day and returns false' do
+      expect(Space.check_availability(
+        spaceid: DEFAULT_SPACE[:id],
+        date: '2017-02-02')
+      ).to be(false)
+    end
+  end
 end

--- a/spec/space_spec.rb
+++ b/spec/space_spec.rb
@@ -102,4 +102,28 @@ describe 'Space' do
       ).to be(false)
     end
   end
+
+  describe '.check_availability_range' do
+    it 'checks a range of available dates and returns true in the end' do
+      Space.add_availability_range(
+        spaceid: DEFAULT_SPACE[:id],
+        start_date: DEFAULT_START_AVAILABILITY,
+        end_date: DEFAULT_END_AVAILABILITY
+      )
+
+      expect(Space.check_availability_range(
+        spaceid: DEFAULT_SPACE[:id],
+        start_date: DEFAULT_START_AVAILABILITY,
+        end_date: DEFAULT_END_AVAILABILITY)
+      ).to be(true)
+    end
+
+    it 'checks a range of unavailable dates and returns false' do
+      expect(Space.check_availability_range(
+        spaceid: DEFAULT_SPACE[:id],
+        start_date: DEFAULT_START_AVAILABILITY,
+        end_date: DEFAULT_END_AVAILABILITY)
+      ).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Adds two availability check methods, one for a single date and one for a range. Tests have been reworked to account for an availability check that's made when a booking is requested. 

Currently raises an error, can instead possibly rework this into a flashed error or something. 